### PR TITLE
各話のプロンプト作成機能に、含める項目を選択するためのチェックボックスを追加しました。

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,6 +207,18 @@
                         </div>
                     </label>
                 </div>
+                <div class="prompt-options">
+                    <label class="prompt-options-label">プロンプトに含める項目:</label>
+                    <div class="prompt-checkbox-group">
+                        <label><input type="checkbox" data-prompt-item="timeSequence" checked> 時系列</label>
+                        <label><input type="checkbox" data-prompt-item="tone" checked> トーン</label>
+                        <label><input type="checkbox" data-prompt-item="subtitle" checked> サブタイトル</label>
+                        <label><input type="checkbox" data-prompt-item="episode" checked> 話数</label>
+                        <label><input type="checkbox" data-prompt-item="length" checked> 長さ</label>
+                        <label><input type="checkbox" data-prompt-item="plot" checked> プロット</label>
+                        <label><input type="checkbox" data-prompt-item="notes" checked> 特記事項</label>
+                    </div>
+                </div>
                  <div class="prompt-output-area">
                     <label>この話のプロンプト出力:</label>
                     <textarea class="subtitle-prompt-output" rows="10" readonly></textarea>

--- a/style.css
+++ b/style.css
@@ -418,6 +418,39 @@ button:active { transform: translateY(1px); }
     font-size: 0.9rem;
 }
 
+/* プロンプト項目選択チェックボックス */
+.prompt-options {
+    margin-top: 1.5rem;
+    padding: 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    background-color: #f8f9fa;
+}
+.prompt-options-label {
+    font-weight: 500;
+    margin-bottom: 0.8rem;
+    display: block;
+    color: var(--text-color);
+}
+.prompt-checkbox-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 0.8rem;
+}
+.prompt-checkbox-group label {
+    display: flex;
+    align-items: center;
+    font-weight: normal;
+    font-size: 0.9rem;
+    margin: 0;
+    cursor: pointer;
+    color: var(--text-light-color);
+}
+.prompt-checkbox-group input[type="checkbox"] {
+    margin-right: 0.5em;
+    width: auto; /* width: 100% を上書き */
+}
+
 /* サブタイトル追加ボタン (FAB) */
 #add-subtitle-button.fab-button {
     position: fixed; 


### PR DESCRIPTION
主な変更点:
- UI: 各話設定エリアに、プロンプトに含める各項目（時系列、トーン、プロットなど）の表示/非表示を切り替えるチェックボックスを追加。
- Logic:
  - チェックボックスの状態はlocalStorageに保存され、リロード後も維持されます。
  - チェックボックスのオン/オフは、プロンプト出力に即座に反映されます。
  - 新規作成時は、すべての項目がデフォルトでオンになります。
  - 既存のデータに対応するため、古いデータ構造を自動で移行する処理を追加しました。
- Style: 新しいチェックボックスセクションに、アプリケーションの他の部分と一貫性のあるスタイルを適用しました。